### PR TITLE
Optionally set docker --host

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,5 @@
 default['k8s']['client_version'] = '0.1.7'
 default['k8s']['master']['ip'] = '127.0.0.1'
 default['k8s']['master']['port'] = '8080'
+
+default['docker']['hosts'] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,6 @@ version          '1.0.1'
 
 depends 'build-essential', '~> 2.2.3'
 depends 'selinux', '~> 0.9.0'
-depends 'docker', '~> 1.0.12'
+depends 'docker', '~> 2.2.8'
 
 supports 'rhel'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'andre@chef.io'
 license          'apache2'
 description      'Manipulate Kubernetes resources'
 long_description 'Deploy a Kubernetes cluster and create, destroy, and update Kubernetes Pods, Services, and Replication Controllers'
-version          '1.0.0'
+version          '1.0.1'
 
 depends 'build-essential', '~> 2.2.3'
 depends 'selinux', '~> 0.9.0'

--- a/providers/master.rb
+++ b/providers/master.rb
@@ -87,6 +87,7 @@ action :create do
   docker_service 'kubernetes' do
     bip lazy { node.run_state[:flannel][:bip] }
     mtu lazy { node.run_state[:flannel][:mtu] }
+    host ['unix:///var/run/docker.sock'] | node['docker']['hosts']
     action [:create,:start]
     notifies :run, 'docker_container[etcd]', :immediately
     notifies :run, 'docker_container[flannel]', :immediately

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -21,6 +21,7 @@ include_recipe '::default'
 include_recipe 'selinux::disabled' if node[:platform_family].eql? "rhel"
 
 docker_service 'kubernetes' do
+  host ['unix:///var/run/docker.sock'] | node['docker']['hosts']
   action [:create, :start]
   retries 5
 end


### PR DESCRIPTION
The 'docker' cookbook LWRP allows us to specify an array of 'host' parameters to allow local and remote access to the docker daemon. This is quite useful in some environments but opens security holes in others. Allowing this to be specified optionally gives us the flexibility of both operating modes. 

This PR also updates to the latest version of the docker cookbook which installs version 1.9 instead of 1.8.
